### PR TITLE
Cakephp2.0, Test Case and Helper configuration

### DIFF
--- a/Test/Case/behaviors/FileUploadTest.php
+++ b/Test/Case/behaviors/FileUploadTest.php
@@ -21,10 +21,10 @@ class FileUploadTest extends CakeTestCase {
   
   function testSetupShouldLoadDefaults(){
     $this->FileUpload->setUp($this->Upload);
-    $options = $this->FileUpload->Uploader->options;
+    $options = $this->FileUpload->Uploader['Upload']->options;
     
-    $this->assertEqual('Upload', $options['fileModel']);
-    $this->assertTrue(strpos($options['uploadDir'], 'webroot/files'));
+    $this->assertEqual('Upload', $options['fileModel']); 
+    $this->assertTextContains('webroot/files', $options['uploadDir']);
     $this->assertEqual('file', $options['fileVar']);
     $this->assertFalse($options['massSave']);
     $this->assertFalse($options['maxFileSize']);
@@ -44,10 +44,10 @@ class FileUploadTest extends CakeTestCase {
       'fileModel' => 'NotValidModel' //should ignore, and set model name to appropriate model
     );
     $this->FileUpload->setUp($this->Upload, $model_options);
-    $options = $this->FileUpload->Uploader->options;
+    $options = $this->FileUpload->Uploader['Upload']->options;
     
-    $this->assertEqual('Upload', $options['fileModel']);
-    $this->assertTrue(strpos($options['uploadDir'], 'webroot/uploads'));
+    $this->assertEqual('Upload', $options['fileModel']);    
+    $this->assertTextContains('webroot/uploads', $options['uploadDir']);
     $this->assertEqual('var', $options['fileVar']);
     $this->assertFalse($options['massSave']);
     $this->assertEqual(10000, $options['maxFileSize']);

--- a/View/Helper/FileUploadHelper.php
+++ b/View/Helper/FileUploadHelper.php
@@ -102,7 +102,6 @@ class FileUploadHelper extends AppHelper{
     * @return mixed html tag, url string, or false if unable to find image. 
     */
   function image($name, $options = array()){
-      debug($this->model());
     $this->fileName = $name;
     //options takes in a width as well
     if(is_int($options)){
@@ -207,7 +206,6 @@ class FileUploadHelper extends AppHelper{
     * @return String upload path of all files
     */
   function _getUploadPath(){
-      debug($this->settings['uploadDir'] . '/' . $this->fileName);
     return $this->settings['uploadDir'] . '/' . $this->fileName;
   }
   

--- a/View/Helper/FileUploadHelper.php
+++ b/View/Helper/FileUploadHelper.php
@@ -64,11 +64,12 @@ class FileUploadHelper extends AppHelper{
     * Constructor, initiallizes the FileUpload Component
     * and sets the default options.
     */
-  function __construct(){
+  function __construct(View $View, $settings = array()){
+    parent::__construct($View, $settings);
     $this->FileUploadSettings = new FileUploadSettings;
     
     //setup settings
-    $this->settings = array_merge($this->FileUploadSettings->defaults, $this->options);
+    $this->settings = array_merge($this->FileUploadSettings->defaults, $settings, $this->options);
   }
   
   /**
@@ -101,6 +102,7 @@ class FileUploadHelper extends AppHelper{
     * @return mixed html tag, url string, or false if unable to find image. 
     */
   function image($name, $options = array()){
+      debug($this->model());
     $this->fileName = $name;
     //options takes in a width as well
     if(is_int($options)){
@@ -205,6 +207,7 @@ class FileUploadHelper extends AppHelper{
     * @return String upload path of all files
     */
   function _getUploadPath(){
+      debug($this->settings['uploadDir'] . '/' . $this->fileName);
     return $this->settings['uploadDir'] . '/' . $this->fileName;
   }
   


### PR DESCRIPTION
Hi !
The Tests were not working for me. Now are ok. 

And I couldn´t change the upload folder from the Helper, now I can do that by passing an array into the Helper declaration. It overrides the default configuration.

For example:

public $helpers = array(
        'FileUpload.FileUpload' => array(
                'uploadDir' => 'img/user_profiles',
            )
        );
