### PR TITLE
Added composer support to Cakephp2.0 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+	"name": "webtechnick/cakephp-fileupload",
+	"description": "WebTechNick's file upload plugin.",
+	"type": "cakephp-plugin",
+	"keywords": ["cakephp", "upload", "webtecknick"],
+	"homepage": "https://github.com/webtechnick/CakePHP-FileUpload-Plugin",
+	"authors": [
+		{
+			"name": "WebTechNick",
+			"homepage": "http://www.webtechnick.com",
+			"role": "Author"
+		}
+	],
+	"extra": {
+		"installer-name": "FileUpload"
+	}
+}

--- a/readme.markdown
+++ b/readme.markdown
@@ -5,11 +5,25 @@
 * BLOG ARTICLE: <http://www.webtechnick.com/blogs/view/221/CakePHP_File_Upload_Plugin>
 
 # INSTALL
-
+## Git clone
 clone into your `app/plugins/file_upload` directory
 	
 	git clone git://github.com/webtechnick/CakePHP-FileUpload-Plugin.git app/plugins/file_upload
 
+## Composer
+Alternatively, use composer package management. Add the following to your composer.json file's repositories/require sections:
+	
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/webtechnick/CakePHP-FileUpload-Plugin.git"
+		}
+	],
+	"require": {
+		"webtechnick/cakephp-fileupload": "dev-cakephp2.0"
+	}
+
+And run `composer install`.
 
 # CHANGELOG:
 * 6.1.1: Fixed a bug that would not display an image if the source image is the same width as the resize image requested. 


### PR DESCRIPTION
Added basic support for the composer package manager (solves #27). The package has not been submitted to packagist.org yet, because it is still a fork. That would ease usage even further since the repositories section (or the particular entry mentioned in the readme) would no longer be needed.
